### PR TITLE
Fix Arrow key for moving along chart #110

### DIFF
--- a/gweatherrouting/gtk/chartstack.py
+++ b/gweatherrouting/gtk/chartstack.py
@@ -71,7 +71,8 @@ class ChartStack(Gtk.Box, ChartStackPOI, ChartStackTrack, ChartStackRouting):
 
         self.map = self.builder.get_object("map")
         self.map.set_center_and_zoom(39.0, 9.0, 6)
-
+        self.map.connect("map", self.on_map_mapped)
+        self.map.connect("button-press-event", self.on_map_clicked)
         self.map.set_keyboard_shortcut(
             OsmGpsMap.MapKey_t.FULLSCREEN, Gdk.keyval_from_name("F11")
         )
@@ -129,6 +130,15 @@ class ChartStack(Gtk.Box, ChartStackPOI, ChartStackTrack, ChartStackRouting):
         self.builder.get_object("stop-routing-button").hide()
         self.progressBar = self.builder.get_object("progressbar")
         self.progressBar.hide()
+        
+    def on_map_clicked(self, widget, event):
+        # First grab focus for the map
+        self.map.grab_focus()
+        # Then proceed with your existing click handling
+        return False  # Return False to allow other handlers to process the event
+    def on_map_mapped(self, widget):
+        # Widget is now visible on screen, safe to grab focus
+        self.map.grab_focus()
 
     def getLatLon(self):
         lat = self.builder.get_object("track-add-point-lat").get_text()


### PR DESCRIPTION
Fix issue #110 
By default, gww starts with focus on the map. If the focus changes (eg, the user clicks the Tab), by clicking on the map, the focus can be reset.