### PR TITLE
Add Flatpak manifest and GitHub Actions workflow for building and packaging

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,56 @@
+
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+name: Build Flatpak
+
+jobs:
+  prepare-deps:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+
+    - name: Create wheels directory
+      run: mkdir -p flatpak/wheels
+
+    - name: Download Python dependencies
+      run: |
+        pip install --upgrade pip wheel
+        pip download -r flatpak/requirements.txt -d flatpak/wheels
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels
+        path: flatpak/wheels
+
+  flatpak-build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
+      options: --privileged
+    needs: prepare-deps
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download wheels
+      uses: actions/download-artifact@v4
+      with:
+        name: wheels
+        path: flatpak/wheels
+
+    - name: Setup Flatpak builder
+      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+      with:
+        bundle: gweatherrouting.flatpak
+        manifest-path: flatpak/org.gweatherrouting.app.yml
+        cache-key: flatpak-builder-${{ github.sha }}

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,8 +1,12 @@
+name: Build Flatpak
+
 on:
   push:
     branches: [main]
   pull_request:
-name: Build Flatpak
+    types: [opened, synchronize, reopened]
+  release:
+    types: [created]
 
 jobs:
   prepare-deps:
@@ -49,6 +53,6 @@ jobs:
     - name: Setup Flatpak builder
       uses: flatpak/flatpak-github-actions/flatpak-builder@v6
       with:
-        bundle: gweatherrouting.flatpak
+        bundle: GWeatherRouting-linux-x86_64.flatpak
         manifest-path: flatpak/org.gweatherrouting.app.yml
         cache-key: flatpak-builder-${{ github.sha }}

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,12 +1,10 @@
-name: Build Flatpak
+
 
 on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened]
-  release:
-    types: [created]
+name: Build Flatpak
 
 jobs:
   prepare-deps:
@@ -53,6 +51,6 @@ jobs:
     - name: Setup Flatpak builder
       uses: flatpak/flatpak-github-actions/flatpak-builder@v6
       with:
-        bundle: GWeatherRouting-linux-x86_64.flatpak
+        bundle: gweatherrouting.flatpak
         manifest-path: flatpak/org.gweatherrouting.app.yml
         cache-key: flatpak-builder-${{ github.sha }}

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, synchronize, reopened]
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   prepare-deps:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,10 +1,12 @@
-
+name: Flatpak
 
 on:
   push:
     branches: [main]
   pull_request:
-name: Build Flatpak
+    types: [opened, synchronize, reopened]
+  release:
+    types: [created]
 
 jobs:
   prepare-deps:
@@ -51,6 +53,6 @@ jobs:
     - name: Setup Flatpak builder
       uses: flatpak/flatpak-github-actions/flatpak-builder@v6
       with:
-        bundle: gweatherrouting.flatpak
+        bundle: GWeatherRouting-linux-x86_64.flatpak
         manifest-path: flatpak/org.gweatherrouting.app.yml
         cache-key: flatpak-builder-${{ github.sha }}

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,5 +1,3 @@
-
-
 on:
   push:
     branches: [main]

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -57,3 +57,9 @@ jobs:
         bundle: GWeatherRouting-linux-x86_64.flatpak
         manifest-path: flatpak/org.gweatherrouting.app.yml
         cache-key: flatpak-builder-${{ github.sha }}
+
+    - name: Upload Flatpak
+      uses: actions/upload-artifact@v4
+      with:
+        name: GWeatherRouting-linux-x86_64.flatpak
+        path: flatpak/org.gweatherrouting.app.flatpak

--- a/flatpak/org.gweatherrouting.app.yml
+++ b/flatpak/org.gweatherrouting.app.yml
@@ -1,0 +1,149 @@
+app-id: org.gweatherrouting.app
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: gweatherrouting
+finish-args:
+  - --share=network
+  - --filesystem=xdg-download
+  - --socket=wayland
+  - --socket=x11
+
+modules:
+
+  - name: sqlite
+    buildsystem: autotools
+    config-opts:
+      - --enable-rtree
+    sources:
+      - type: archive
+        url: https://sqlite.org/2025/sqlite-autoconf-3490200.tar.gz
+        sha256: 5c6d8697e8a32a1512a9be5ad2b2e7a891241c334f56f8b0fb4fc6051e1652e8
+
+  - name: proj
+    buildsystem: cmake
+    config-opts:
+      - -DBUILD_TESTING=OFF
+    sources:
+      - type: archive
+        url: https://download.osgeo.org/proj/proj-9.3.1.tar.gz
+        sha256: b0f919cb9e1f42f803a3e616c2b63a78e4d81ecfaed80978d570d3a5e29d10bc
+
+  - name: geos
+    buildsystem: cmake-ninja
+    sources:
+      - type: archive
+        url: http://download.osgeo.org/geos/geos-3.13.1.tar.bz2
+        sha256: df2c50503295f325e7c8d7b783aca8ba4773919cde984193850cf9e361dfd28c
+        x-checker-data:
+          type: anitya
+          project-id: 13493
+          url-template: http://download.osgeo.org/geos/geos-$version.tar.bz2
+          stable-only: true
+
+  - name: python-numpy
+    buildsystem: simple
+    sources:
+      - type: dir
+        path: wheels
+        dest: wheels
+    build-commands:
+      - pip3 install --no-index --find-links=${PWD}/wheels --prefix=/app numpy
+
+  - name: swig
+    buildsystem: autotools
+    config-opts:
+      - --without-boost
+      - --without-pcre
+      - --without-alllang
+      - --with-python3
+    cleanup:
+      - /bin
+      - /share/swig
+    sources:
+      - type: archive
+        url: http://prdownloads.sourceforge.net/swig/swig-4.3.1.tar.gz
+        sha256: 44fc829f70f1e17d635a2b4d69acab38896699ecc24aa023e516e0eabbec61b8
+        x-checker-data:
+          type: anitya
+          project-id: 4919
+          url-template: http://prdownloads.sourceforge.net/swig/swig-$version.tar.gz
+          stable-only: true
+
+  - name: json-c
+    buildsystem: cmake-ninja
+    builddir: true
+    sources:
+      - type: git
+        url: https://github.com/json-c/json-c
+        tag: json-c-0.18-20240915
+        commit: 41a55cfcedb54d9c1874f2f0eb07b504091d7e37
+        x-checker-data:
+          type: git
+          tag-pattern: '^json-c-([\d.]+)-[\d]+$'
+
+  - name: gdal
+    buildsystem: cmake
+    config-opts:
+      - -DBUILD_PYTHON_BINDINGS=ON
+      - -DGDAL_USE_GEOTIFF_INTERNAL=ON
+      - -DGDAL_USE_GEOS=ON
+      - -DGDAL_USE_JSONC=ON
+      - -DGDAL_USE_CRYPTOPP=OFF
+      - -DGDAL_USE_XERCESC=OFF
+      - -DGDAL_USE_DEFLATE=OFF
+      - -DGDAL_USE_INTERNAL_LIBS=OFF
+      - -DBUILD_SHARED_LIBS=ON
+      - -DGDAL_USE_PROJ=ON
+      - -DPROJ_INCLUDE_DIR=/app/include
+      - -DPROJ_LIBRARY=/app/lib/libproj.so
+      - -DGDAL_BUILD_PYTHON_BINDINGS=ON 
+      - -DPython3_EXECUTABLE=/app/bin/python3
+    sources:
+      - type: archive
+        url: https://github.com/OSGeo/gdal/releases/download/v3.9.3/gdal-3.9.3.tar.gz
+        sha256: f293d8ccc6b98f617db88f8593eae37f7e4b32d49a615b2cba5ced12c7bebdae
+
+  - name: libsoup
+    buildsystem: meson
+    config-opts:
+      - -Dgtk_doc=false
+      - -Dintrospection=disabled
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/GNOME/libsoup.git
+        tag: '2.74.2'
+        
+  - name: osm-gps-map
+    buildsystem: autotools
+    config-opts: []
+    sources:
+      - type: archive
+        url: https://github.com/nzjrs/osm-gps-map/archive/refs/tags/1.2.0.tar.gz
+        sha256: a5d97b96366c876f83a4fb3d9b45ac58b6a2600cfce25043fb6d7a15b8299e65
+
+  - name: python-deps
+    buildsystem: simple
+    sources:
+      - type: dir
+        path: wheels
+        dest: wheels
+    build-commands:
+      - pip3 install --no-deps --no-index --find-links=${PWD}/wheels --prefix=/app vext
+      - pip3 install --no-index --find-links=${PWD}/wheels --prefix=/app setuptools setuptools_scm[toml]
+      - pip3 install --no-index --find-links=${PWD}/wheels --prefix=/app requests colorlog geojson_utils beautifulsoup4
+      - pip3 install --no-index --find-links=${PWD}/wheels --prefix=/app pyserial pynmea2 gpxpy matplotlib
+      - pip3 install --no-index --find-links=${PWD}/wheels --prefix=/app ruamel.yaml ruamel.yaml.clib nmeatoolkit weatherrouting
+
+  - name: gweatherrouting
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps --no-index --find-links=${PWD}/../python-deps/wheels --prefix=/app --no-build-isolation .
+    sources:
+      - type: git
+        url: https://github.com/dakk/gweatherrouting.git
+        branch: master
+        
+cleanup:
+  - /app/include
+  - /app/lib/pkgconfig

--- a/flatpak/requirements.txt
+++ b/flatpak/requirements.txt
@@ -1,0 +1,16 @@
+vext
+ruamel.yaml
+ruamel.yaml.clib
+requests
+colorlog
+geojson_utils
+beautifulsoup4
+pyserial
+pynmea2
+gpxpy
+numpy
+matplotlib
+nmeatoolkit
+weatherrouting
+setuptools
+setuptools_scm[toml]


### PR DESCRIPTION
This PR introduces a complete Flatpak build setup for the project:

- Adds a `flatpak/org.gweatherrouting.app.yaml` manifest
- Includes required modules and Python dependencies
- Adds a `flatpak-build.yml` GitHub Actions workflow to automate:
  - Downloading required Python wheels
  - Building the Flatpak bundle
  - Uploading the `.flatpak` as an artifact

Key features:
- Supports GNOME 48 runtime
- Ensures reproducible builds using pinned dependencies
- Bundles all Python modules locally using wheels
- Enables sandboxed execution with minimal permissions

Tested locally and via GitHub CI.

This should make it easier for users to try out the application via Flatpak, and lays the groundwork for potential future submission to Flathub.

Let me know if anything should be adjusted or split into separate commits.
